### PR TITLE
Updated to 1.20.2 and fixed issues #4 #5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-	compile 'org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT'
+	compile "org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT"
 	testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/java/net/querz/openshulkerbox/OpenShulkerBoxListener.java
+++ b/src/main/java/net/querz/openshulkerbox/OpenShulkerBoxListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.*;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -173,6 +174,16 @@ public class OpenShulkerBoxListener implements Listener {
 			}
 		}
 	}
+
+    @EventHandler
+    public void onItemDrop(PlayerDropItemEvent event){ //Because Pressing Q can dupe items
+        HumanEntity player;
+        if (shulkerBoxSlots.containsKey((player = event.getPlayer()).getUniqueId())) {
+            ItemStack[] items = player.getOpenInventory().getTopInventory().getContents(); //Only called if inv is open
+            saveShulkerBox(player, items);
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_SHULKER_BOX_CLOSE, .1F, 1.0F);
+        }
+    }
 
 	private void saveShulkerBox(HumanEntity player, ItemStack[] items) {
         ItemStack shulkerbox = shulkerBoxOnCursors.contains(player.getUniqueId())  //Check if the shulkerbox is on the cursor

--- a/src/main/java/net/querz/openshulkerbox/OpenShulkerBoxListener.java
+++ b/src/main/java/net/querz/openshulkerbox/OpenShulkerBoxListener.java
@@ -77,6 +77,7 @@ public class OpenShulkerBoxListener implements Listener {
 			//close inventory if opened shulker box is dropped
 			if (shulkerBoxSlots.get(player.getUniqueId()).equals(event.getRawSlot())) {
 				if (isPickupAction(event.getAction())) {
+                    shulkerBoxSlots.put(player.getUniqueId(),-3141); //Move Shulkerbox to impossible slot to avoid bugs :)
 					shulkerBoxOnCursors.add(player.getUniqueId());
 					return;
 				} else if (event.getAction() == InventoryAction.DROP_ALL_SLOT
@@ -174,7 +175,10 @@ public class OpenShulkerBoxListener implements Listener {
 	}
 
 	private void saveShulkerBox(HumanEntity player, ItemStack[] items) {
-		ItemStack shulkerbox = player.getInventory().getItem(toSlot(shulkerBoxSlots.get(player.getUniqueId())));
+        ItemStack shulkerbox = shulkerBoxOnCursors.contains(player.getUniqueId())  //Check if the shulkerbox is on the cursor
+                ? player.getItemOnCursor()
+                : player.getInventory().getItem(toSlot(shulkerBoxSlots.get(player.getUniqueId())));
+
 		if (shulkerbox == null || !isShulkerBox(shulkerbox.getType())) {
 			return;
 		}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,4 +2,4 @@ name: OpenShulkerBox
 author: Querz
 version: @plugin.version@
 main: net.querz.openshulkerbox.OpenShulkerBoxPlugin
-api-version: 1.13
+api-version: 1.20


### PR DESCRIPTION
Updated Version

Issue #4:
Happened because pressing the drop button wasn't always registered -> Added new Event to save if pressed.

Issue #5:
Happened because the slot where the shulkerbox was didn't get changed, if it was picked up by the cursor. The method saveShulkerBox then saved the opened inventory to the old slot instead on the picked up item. -> Set the slot to an impossible value. If the Shulkerbox is on the cursor. Save it on the item on the cursor.